### PR TITLE
Update/margin collapse max width wrapper

### DIFF
--- a/src/components/hero/homeHero.js
+++ b/src/components/hero/homeHero.js
@@ -7,7 +7,7 @@ export const HomeHero = ({ content }) => {
   const theme = useTheme()
 
   return (
-    <MaxWidthWrapper backgroundColor={theme.palette.branding.deepPurple}>
+    <MaxWidthWrapper backgroundColor={theme.palette.branding.deepPurple} sx={{ my: 0 }}>
       <Box
         sx={{
           height: '400px',

--- a/src/components/layout/maxWidthWrapper.js
+++ b/src/components/layout/maxWidthWrapper.js
@@ -5,10 +5,11 @@ export const MaxWidthWrapper = ({
   maxWidth = 'lg',
   backgroundColor = 'transparent',
   children,
+  sx
 }) => {
   return (
-    <Box sx={{ backgroundColor, width: "100%" }}>
-      <Container maxWidth={maxWidth} sx={{ paddingY: '4rem' }}>
+    <Box sx={{ backgroundColor, width: "100%", display: 'flow-root' }}> {/* flow-root disables margin collapse */}
+      <Container maxWidth={maxWidth} sx={{ marginY: '4rem', ...sx}}>
         {children}
       </Container>
     </Box>

--- a/src/components/sections/rotatingVerbs.js
+++ b/src/components/sections/rotatingVerbs.js
@@ -7,7 +7,7 @@ export const RotatingVerbs = ({ content: { heading, verbs, subheading } }) => {
   const theme = useTheme();
   
   return (
-    <MaxWidthWrapper backgroundColor={theme.palette.branding.offWhite}>
+    <MaxWidthWrapper backgroundColor={theme.palette.branding.offWhite} sx={{ mb: 0 }}>
       <Stack flexDirection='column' alignItems='center'>
         <Typography
           variant="h1"


### PR DESCRIPTION
Removes the padding and switches to marginY with `display: flow-root` on the parent so that sections' margins don't collapse on each other.

More importantly, `<MaxWidthWrapper />` now takes a `sx` prop, which can be used to turn of the default margin on each component. For this PR I removed:

- bottom margin from rotating verb component
- top/bottom margin on home hero section